### PR TITLE
Support new BuzzCard data format

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21")
-        classpath("com.android.tools.build:gradle:7.3.0-rc01")
+        classpath("com.android.tools.build:gradle:7.3.1")
         classpath("com.google.dagger:hilt-android-gradle-plugin:2.40.1")
         classpath("com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1")
         classpath("com.google.gms:google-services:4.3.10")


### PR DESCRIPTION
Now a `=` or `0` is expected after the GTID in the prox string and nothing after that is validated. Only the first 9 characters of the prox string are taken as the GTID, and then the extracted characters are validated against a GTID regex just in case.